### PR TITLE
fix: skip readiness check for Dependabot PRs

### DIFF
--- a/.github/workflows/readiness.yml
+++ b/.github/workflows/readiness.yml
@@ -37,6 +37,7 @@ permissions:
 
 jobs:
   readiness:
+    if: github.actor != 'dependabot[bot]'
     runs-on: ubuntu-latest
     steps:
       # ── Step 1: Generate App token ──────────────────────────────────


### PR DESCRIPTION
## Summary
- Skip the readiness job when `github.actor` is `dependabot[bot]`
- Dependabot runs can't access repo secrets, so the app token generation step always fails
- Readiness is informational only — the merge workflow independently verifies CI before allowing `/merge`

## Test plan
- [ ] Open a Dependabot PR on a consuming repo — readiness should show as "skipped" instead of failing
- [ ] Open a regular PR — readiness should still run normally