### PR TITLE
fix: match breaking change marker (!) in commit regex

### DIFF
--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -386,7 +386,7 @@ jobs:
 
             for (const c of commits) {
               const msg = c.commit.message.split('\n')[0];
-              const match = msg.match(/^(\w+)(?:\(.*?\))?:\s*(.+)$/);
+              const match = msg.match(/^(\w+)(?:\(.*?\))?!?:\s*(.+)$/);
               if (!match) continue;
               const sec = sectionMap[match[1].toLowerCase()];
               if (!sec) continue;

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,3 +32,4 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Fix readiness version preview falling through to 'no bump' when `--major` is passed — now correctly previews `0.x.x → 1.0.0` ([#16](https://github.com/coloneljade/merge-bot/pull/16))
 - Add `--major` to the commands table in README ([#16](https://github.com/coloneljade/merge-bot/pull/16))
 - Update Version Behavior section to accurately describe that major bumps are manual-flag-triggered, not unsupported ([#16](https://github.com/coloneljade/merge-bot/pull/16))
+- Match breaking change marker (!) in commit regex ([#21](https://github.com/coloneljade/merge-bot/pull/21))


### PR DESCRIPTION
### Fixed

- Commit regex now matches breaking change marker (`!`) per Conventional Commits spec (Fixes #20)

## Test Plan

- [ ] Verified CHANGELOG correctly includes commits using `feat!:` and `feat(scope)!:` syntax