### PR TITLE
chore: add commit-msg hook and enhance pre-push with commit validation

### DIFF
--- a/.githooks/commit-msg
+++ b/.githooks/commit-msg
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+# Validate commit message format against conventional commit syntax.
+#
+# Algorithm:
+#   1. Read the commit message file (path passed as $1 by git)
+#   2. Extract the first line (subject), stripping comment lines
+#   3. Allow empty subjects — git will abort the commit on its own
+#   4. Allow merge commits ("Merge ...") and revert commits ("Revert ...")
+#   5. Validate subject matches: type(optional-scope)!?: description
+#   6. Validate the type against the known allow list
+#   7. Reject with an actionable error if validation fails
+#
+# The regex and type list are aligned with merge-bot's commit parser so
+# commits accepted here will be parseable by the CHANGELOG generator.
+# The `wip` type is additionally allowed for checkpoint commits during
+# development; these are blocked at push time by the pre-push hook.
+#
+# Exit 0: commit message is valid
+# Exit 1: commit message is malformed or uses an unknown type
+
+set -euo pipefail
+
+MSG_FILE="$1"
+SUBJECT=$(head -1 "$MSG_FILE" | sed 's/^#.*//')
+
+# Allow empty subject — git will abort the commit on its own
+if [ -z "$SUBJECT" ]; then
+  exit 0
+fi
+
+# Allow merge commits and revert commits
+if [[ "$SUBJECT" =~ ^Merge\  ]] || [[ "$SUBJECT" =~ ^Revert\  ]]; then
+  exit 0
+fi
+
+# Validate conventional commit format: type(optional-scope)!?: description
+if ! [[ "$SUBJECT" =~ ^([a-zA-Z]+)(\(.*\))?\!?:[[:space:]].+ ]]; then
+  echo "error: commit message does not match conventional format"
+  echo "  expected: type(scope): description"
+  echo "  got:      $SUBJECT"
+  echo ""
+  echo "Valid types: feat, fix, refactor, perf, security, docs, test, chore, ci, build, style, wip"
+  exit 1
+fi
+
+TYPE="${BASH_REMATCH[1]}"
+VALID_TYPES="feat fix refactor perf security docs test chore ci build style wip"
+
+for valid in $VALID_TYPES; do
+  if [ "$TYPE" = "$valid" ]; then
+    exit 0
+  fi
+done
+
+echo "error: unknown commit type \"$TYPE\""
+echo "Valid types: feat, fix, refactor, perf, security, docs, test, chore, ci, build, style, wip"
+exit 1

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,48 +1,134 @@
 #!/usr/bin/env bash
-# Validate that the current branch uses a recognized type/ prefix.
+# Validate branch name and all outgoing commit messages before push.
 #
 # Algorithm:
 #   1. Read the current branch name
 #   2. Allow main and detached HEAD unconditionally
-#   3. Extract the prefix (everything before the first /)
-#   4. Check prefix against the allow list of conventional branch types
-#   5. Reject with an actionable error if the prefix is not recognized
+#   3. Validate branch uses type/description format with a recognized prefix
+#   4. Read stdin for remote ref and local/remote SHAs (provided by git)
+#   5. For each ref being pushed, determine new commits not yet on the remote
+#   6. Skip delete operations and refs with no new commits
+#   7. For new branches, compare against origin/main as the base
+#   8. Validate every new commit message matches conventional format
+#   9. Reject wip: commits — allowed locally but must not reach the remote
+#  10. Report all errors with short SHA and subject, then fail
 #
-# The allow list covers all conventional commit types plus "feature" as a
-# common alias for "feat". This is intentionally broader than the merge bot's
-# bump-map — a branch can be valid (e.g., docs/) even if it doesn't trigger
-# a version bump.
+# Branch validation matches merge-bot's pre-push hook. Commit validation
+# mirrors the commit-msg hook but catches commits that bypassed it (e.g.,
+# --no-verify, cherry-pick, rebase).
 #
-# Exit 0: branch name is valid
-# Exit 1: branch name uses an unrecognized prefix
+# Exit 0: branch and all commits are valid
+# Exit 1: branch name invalid, or one or more commits have bad messages
 
 set -euo pipefail
 
 BRANCH=$(git rev-parse --abbrev-ref HEAD)
 
-# Always allow main and detached HEAD
-if [ "$BRANCH" = "main" ] || [ "$BRANCH" = "HEAD" ]; then
-  exit 0
-fi
+# --- Branch name validation ---
 
-# Extract prefix (everything before the first /)
-PREFIX="${BRANCH%%/*}"
+if [ "$BRANCH" != "main" ] && [ "$BRANCH" != "HEAD" ]; then
+  PREFIX="${BRANCH%%/*}"
 
-# Reject if no / separator (prefix equals the full branch name)
-if [ "$PREFIX" = "$BRANCH" ]; then
-  echo "error: branch \"$BRANCH\" must use type/description format (e.g., feat/my-feature)"
-  echo "Valid prefixes: feature, feat, fix, refactor, docs, chore, ci, test, style, perf, security"
-  exit 1
-fi
-
-VALID_PREFIXES="feature feat fix refactor docs chore ci test style perf security"
-
-for valid in $VALID_PREFIXES; do
-  if [ "$PREFIX" = "$valid" ]; then
-    exit 0
+  if [ "$PREFIX" = "$BRANCH" ]; then
+    echo "error: branch \"$BRANCH\" must use type/description format (e.g., feat/my-feature)"
+    echo "Valid prefixes: feature, feat, fix, refactor, docs, chore, ci, test, style, perf, security"
+    exit 1
   fi
+
+  VALID_PREFIXES="feature feat fix refactor docs chore ci test style perf security"
+  prefix_valid=false
+  for valid in $VALID_PREFIXES; do
+    if [ "$PREFIX" = "$valid" ]; then
+      prefix_valid=true
+      break
+    fi
+  done
+
+  if [ "$prefix_valid" = false ]; then
+    echo "error: unrecognized branch prefix \"$PREFIX\" in branch \"$BRANCH\""
+    echo "Valid prefixes: feature, feat, fix, refactor, docs, chore, ci, test, style, perf, security"
+    exit 1
+  fi
+fi
+
+# --- Commit message validation ---
+
+ZERO="0000000000000000000000000000000000000000"
+VALID_TYPES="feat fix refactor perf security docs test chore ci build style"
+errors=0
+
+while read -r local_ref local_sha remote_ref remote_sha; do
+  # Skip delete operations
+  if [ "$local_sha" = "$ZERO" ]; then
+    continue
+  fi
+
+  # Determine commit range
+  if [ "$remote_sha" = "$ZERO" ]; then
+    # New branch — compare against origin/main
+    if git rev-parse --verify origin/main >/dev/null 2>&1; then
+      range="origin/main..$local_sha"
+    else
+      # Fresh repo with no origin/main — validate all commits
+      range="$local_sha"
+    fi
+  else
+    range="$remote_sha..$local_sha"
+  fi
+
+  # Get commit subjects in the range
+  commits=$(git log --format="%H %s" "$range" 2>/dev/null) || continue
+
+  if [ -z "$commits" ]; then
+    continue
+  fi
+
+  while IFS= read -r line; do
+    sha="${line%% *}"
+    subject="${line#* }"
+    short_sha="${sha:0:7}"
+
+    # Allow merge and revert commits
+    if [[ "$subject" =~ ^Merge\  ]] || [[ "$subject" =~ ^Revert\  ]]; then
+      continue
+    fi
+
+    # Validate format
+    if ! [[ "$subject" =~ ^([a-zA-Z]+)(\(.*\))?\!?:[[:space:]].+ ]]; then
+      echo "error: commit $short_sha has malformed message: $subject"
+      errors=$((errors + 1))
+      continue
+    fi
+
+    type="${BASH_REMATCH[1]}"
+
+    # Reject wip commits at push time
+    if [ "$type" = "wip" ]; then
+      echo "error: commit $short_sha is a wip commit and cannot be pushed: $subject"
+      echo "  hint: squash or reword wip commits before pushing"
+      errors=$((errors + 1))
+      continue
+    fi
+
+    # Validate type
+    type_valid=false
+    for valid in $VALID_TYPES; do
+      if [ "$type" = "$valid" ]; then
+        type_valid=true
+        break
+      fi
+    done
+
+    if [ "$type_valid" = false ]; then
+      echo "error: commit $short_sha has unknown type \"$type\": $subject"
+      errors=$((errors + 1))
+    fi
+  done <<< "$commits"
 done
 
-echo "error: unrecognized branch prefix \"$PREFIX\" in branch \"$BRANCH\""
-echo "Valid prefixes: feature, feat, fix, refactor, docs, chore, ci, test, style, perf, security"
-exit 1
+if [ "$errors" -gt 0 ]; then
+  echo ""
+  echo "Valid types: feat, fix, refactor, perf, security, docs, test, chore, ci, build, style"
+  echo "($errors commit(s) failed validation)"
+  exit 1
+fi

--- a/README.md
+++ b/README.md
@@ -251,6 +251,18 @@ with:
 
 For non-JSON files (default), the bot uses the `version-xpath` input as the XML element name. This is the original behavior for `.NET` repos using `Directory.Build.props`.
 
+## Development
+
+After cloning, configure git to use the repo's commit hooks:
+
+```bash
+git config core.hooksPath .githooks
+```
+
+This enables:
+- **commit-msg** — validates conventional commit format at creation time
+- **pre-push** — validates branch naming and all outgoing commit messages
+
 ## Versioning
 
 The `@v1` tag always points to the latest commit on `main`. Consumers referencing `@v1` automatically get updates without changing their workflow files.


### PR DESCRIPTION
## Summary

- Add `commit-msg` hook validating conventional commit format at creation time
- Enhance `pre-push` hook with commit message validation (was branch-name-only)
- Document hook setup in README Development section

### Changed

- `.githooks/pre-push` now validates all outgoing commit messages in addition to branch names
- Rejects `wip:` commits at push time (allowed locally for checkpoints)

### Added

- `.githooks/commit-msg` validates conventional commit format with `wip` type support
- README "Development" section with hook setup instructions

## Test Plan

- [x] `git commit -m "bad message"` → rejected by commit-msg hook
- [x] `git commit -m "feat: test"` → accepted
- [x] Hooks are identical to proven auldrant-api hooks (PR #27)