### PR TITLE
fix: allow readiness check to pass for dependabot PRs

### DIFF
--- a/.github/workflows/readiness.yml
+++ b/.github/workflows/readiness.yml
@@ -36,11 +36,11 @@ permissions:
 
 jobs:
   readiness:
-    if: github.actor != 'dependabot[bot]'
     runs-on: ubuntu-latest
     steps:
       # ── Step 1: Generate App token ──────────────────────────────────
       - name: Generate App token
+        if: github.actor != 'dependabot[bot]'
         id: app-token
         uses: actions/create-github-app-token@v1
         with:
@@ -49,6 +49,7 @@ jobs:
 
       # ── Step 2: Get PR details ──────────────────────────────────────
       - name: Get PR details
+        if: github.actor != 'dependabot[bot]'
         id: pr-info
         uses: actions/github-script@v7
         with:
@@ -69,6 +70,7 @@ jobs:
 
       # ── Step 3: Determine bump preview ─────────────────────────────
       - name: Determine bump preview
+        if: github.actor != 'dependabot[bot]'
         id: bump
         uses: actions/github-script@v7
         with:
@@ -84,7 +86,7 @@ jobs:
       # ── Step 4: Check version file ─────────────────────────────────
       - name: Check version file
         id: version
-        if: steps.bump.outputs.type != 'none'
+        if: github.actor != 'dependabot[bot]' && steps.bump.outputs.type != 'none'
         uses: actions/checkout@v4
         with:
           token: ${{ steps.app-token.outputs.token }}
@@ -93,7 +95,7 @@ jobs:
 
       - name: Read version preview
         id: version-info
-        if: steps.bump.outputs.type != 'none'
+        if: github.actor != 'dependabot[bot]' && steps.bump.outputs.type != 'none'
         uses: actions/github-script@v7
         with:
           script: |
@@ -137,6 +139,7 @@ jobs:
 
       # ── Step 5: Post or update sticky comment ──────────────────────
       - name: Post readiness comment
+        if: github.actor != 'dependabot[bot]'
         uses: actions/github-script@v7
         with:
           github-token: ${{ steps.app-token.outputs.token }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,3 +33,4 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Add `--major` to the commands table in README ([#16](https://github.com/coloneljade/merge-bot/pull/16))
 - Update Version Behavior section to accurately describe that major bumps are manual-flag-triggered, not unsupported ([#16](https://github.com/coloneljade/merge-bot/pull/16))
 - Match breaking change marker (!) in commit regex ([#21](https://github.com/coloneljade/merge-bot/pull/21))
+- Allow readiness check to pass for dependabot PRs ([#23](https://github.com/coloneljade/merge-bot/pull/23))


### PR DESCRIPTION
## Summary

- The readiness job was entirely skipped (`if: github.actor != 'dependabot[bot]'` at job level) for dependabot PRs, causing the `readiness / readiness` required status check to report as "skipping" — which blocks the merge
- Moved the actor check to step-level conditions so the job always runs (satisfying the required check) but short-circuits all steps for dependabot PRs

## Context

Part of migrating `required_signatures` from legacy branch protection to rulesets with dependabot bypass. The readiness skip was the other half of why dependabot PRs couldn't merge.

## Test plan

- [ ] Verify the readiness check passes (not skips) on a dependabot PR after this ships
- [ ] Verify readiness still posts the full comment on non-dependabot PRs