### PR TITLE
fix(ci): bump actions to Node.js 24 compatible versions

### DIFF
--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -38,7 +38,7 @@ jobs:
       # ── Step 1: Parse command and react ─────────────────────────────
       - name: Parse command and acknowledge
         id: parse
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             const comment = context.payload.comment.body.trim();
@@ -72,7 +72,7 @@ jobs:
       # ── Step 2: Generate App token ──────────────────────────────────
       - name: Generate App token
         id: app-token
-        uses: actions/create-github-app-token@v1
+        uses: actions/create-github-app-token@v3
         with:
           app-id: ${{ secrets.app-id }}
           private-key: ${{ secrets.private-key }}
@@ -80,7 +80,7 @@ jobs:
       # ── Step 3: Verify commenter permissions ────────────────────────
       - name: Verify commenter has write access
         id: auth
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           github-token: ${{ steps.app-token.outputs.token }}
           script: |
@@ -104,7 +104,7 @@ jobs:
       # ── Step 4: Verify PR state ────────────────────────────────────
       - name: Verify PR is mergeable
         id: pr-info
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           github-token: ${{ steps.app-token.outputs.token }}
           script: |
@@ -158,7 +158,7 @@ jobs:
 
       # ── Step 5: Wait for CI checks to pass ────────────────────────
       - name: Wait for CI checks to pass
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           github-token: ${{ steps.app-token.outputs.token }}
           script: |
@@ -232,7 +232,7 @@ jobs:
 
       # ── Step 6: Checkout PR branch ─────────────────────────────────
       - name: Checkout PR branch
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           token: ${{ steps.app-token.outputs.token }}
           ref: ${{ steps.pr-info.outputs.branch }}
@@ -241,7 +241,7 @@ jobs:
       # ── Step 7: Determine bump type ────────────────────────────────
       - name: Determine bump type
         id: bump
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             const branch = '${{ steps.pr-info.outputs.branch }}';
@@ -286,7 +286,7 @@ jobs:
       - name: Read current version
         id: version
         if: steps.bump.outputs.type != 'none'
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             const fs = require('fs');
@@ -354,7 +354,7 @@ jobs:
       - name: Generate CHANGELOG entry
         id: changelog
         if: steps.bump.outputs.type != 'none'
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           github-token: ${{ steps.app-token.outputs.token }}
           script: |
@@ -495,7 +495,7 @@ jobs:
 
       - name: Update version file (XML)
         if: steps.bump.outputs.type != 'none' && steps.changelog.outputs.skip != 'true' && steps.version.outputs.skip != 'true' && !endsWith(inputs.version-file, '.json')
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             const fs = require('fs');
@@ -538,7 +538,7 @@ jobs:
       - name: Wait for CI on bumped commit
         id: wait-ci
         if: steps.commit.outputs.sha
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           github-token: ${{ steps.app-token.outputs.token }}
           script: |
@@ -614,7 +614,7 @@ jobs:
       # ── Step 13: Merge the PR ──────────────────────────────────────
       - name: Merge PR
         id: do-merge
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           github-token: ${{ steps.app-token.outputs.token }}
           script: |
@@ -664,7 +664,7 @@ jobs:
       # ── Step 14: Post summary and react ────────────────────────────
       - name: Post merge summary
         if: steps.do-merge.outputs.merged == 'true'
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           github-token: ${{ steps.app-token.outputs.token }}
           script: |

--- a/.github/workflows/readiness.yml
+++ b/.github/workflows/readiness.yml
@@ -42,7 +42,7 @@ jobs:
       - name: Generate App token
         if: github.actor != 'dependabot[bot]'
         id: app-token
-        uses: actions/create-github-app-token@v1
+        uses: actions/create-github-app-token@v3
         with:
           app-id: ${{ secrets.app-id }}
           private-key: ${{ secrets.private-key }}
@@ -51,7 +51,7 @@ jobs:
       - name: Get PR details
         if: github.actor != 'dependabot[bot]'
         id: pr-info
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           github-token: ${{ steps.app-token.outputs.token }}
           script: |
@@ -72,7 +72,7 @@ jobs:
       - name: Determine bump preview
         if: github.actor != 'dependabot[bot]'
         id: bump
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             const branch = '${{ steps.pr-info.outputs.branch }}';
@@ -87,7 +87,7 @@ jobs:
       - name: Check version file
         id: version
         if: github.actor != 'dependabot[bot]' && steps.bump.outputs.type != 'none'
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           token: ${{ steps.app-token.outputs.token }}
           ref: ${{ steps.pr-info.outputs.base }}
@@ -96,7 +96,7 @@ jobs:
       - name: Read version preview
         id: version-info
         if: github.actor != 'dependabot[bot]' && steps.bump.outputs.type != 'none'
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             const fs = require('fs');
@@ -140,7 +140,7 @@ jobs:
       # ── Step 5: Post or update sticky comment ──────────────────────
       - name: Post readiness comment
         if: github.actor != 'dependabot[bot]'
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           github-token: ${{ steps.app-token.outputs.token }}
           script: |

--- a/.github/workflows/update-tag.yml
+++ b/.github/workflows/update-tag.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Update v1 tag
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             const tag = 'v1';

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,3 +34,4 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Update Version Behavior section to accurately describe that major bumps are manual-flag-triggered, not unsupported ([#16](https://github.com/coloneljade/merge-bot/pull/16))
 - Match breaking change marker (!) in commit regex ([#21](https://github.com/coloneljade/merge-bot/pull/21))
 - Allow readiness check to pass for dependabot PRs ([#23](https://github.com/coloneljade/merge-bot/pull/23))
+- Bump actions to Node.js 24 compatible versions ([#24](https://github.com/coloneljade/merge-bot/pull/24))


### PR DESCRIPTION
## Summary

- `actions/checkout` v4 → v6
- `actions/create-github-app-token` v1 → v3
- `actions/github-script` v7 → v9

Node.js 20 actions are deprecated — forced to Node.js 24 starting June 2, 2026 and removed Sep 16, 2026. All three actions were flagging deprecation warnings on every workflow run.

Note: `github-script` v9 drops `require('@actions/github')` support (ESM-only). Verified no scripts use that pattern — all use the injected `github` context.

## Test plan

- [ ] Readiness check passes without Node.js 20 warnings
- [ ] Merge workflow succeeds on a test PR