### PR TITLE
fix!: replace deprecated app-id input with client-id

### DIFF
--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -20,7 +20,7 @@ on:
         type: string
         default: 'CHANGELOG.md'
     secrets:
-      app-id:
+      client-id:
         required: true
       private-key:
         required: true
@@ -74,7 +74,7 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@v3
         with:
-          app-id: ${{ secrets.app-id }}
+          client-id: ${{ secrets.client-id }}
           private-key: ${{ secrets.private-key }}
 
       # ── Step 3: Verify commenter permissions ────────────────────────

--- a/.github/workflows/readiness.yml
+++ b/.github/workflows/readiness.yml
@@ -24,7 +24,7 @@ on:
         type: string
         required: true
     secrets:
-      app-id:
+      client-id:
         required: true
       private-key:
         required: true
@@ -44,7 +44,7 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@v3
         with:
-          app-id: ${{ secrets.app-id }}
+          client-id: ${{ secrets.client-id }}
           private-key: ${{ secrets.private-key }}
 
       # ── Step 2: Get PR details ──────────────────────────────────────

--- a/.github/workflows/self-merge.yml
+++ b/.github/workflows/self-merge.yml
@@ -19,5 +19,5 @@ jobs:
     if: github.event.issue.pull_request && startsWith(github.event.comment.body, '/merge')
     uses: ./.github/workflows/merge.yml
     secrets:
-      app-id: ${{ secrets.MERGE_APP_ID }}
+      client-id: ${{ secrets.MERGE_CLIENT_ID }}
       private-key: ${{ secrets.MERGE_APP_PRIVATE_KEY }}

--- a/.github/workflows/self-readiness.yml
+++ b/.github/workflows/self-readiness.yml
@@ -17,5 +17,5 @@ jobs:
       pr-number: ${{ github.event.pull_request.number }}
       pr-sha: ${{ github.event.pull_request.head.sha }}
     secrets:
-      app-id: ${{ secrets.MERGE_APP_ID }}
+      client-id: ${{ secrets.MERGE_CLIENT_ID }}
       private-key: ${{ secrets.MERGE_APP_PRIVATE_KEY }}

--- a/.github/workflows/update-tag.yml
+++ b/.github/workflows/update-tag.yml
@@ -11,11 +11,11 @@ jobs:
   update-tag:
     runs-on: ubuntu-latest
     steps:
-      - name: Update v1 tag
+      - name: Update v2 tag
         uses: actions/github-script@v9
         with:
           script: |
-            const tag = 'v1';
+            const tag = 'v2';
             const ref = `tags/${tag}`;
             const sha = context.sha;
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,3 +35,4 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Match breaking change marker (!) in commit regex ([#21](https://github.com/coloneljade/merge-bot/pull/21))
 - Allow readiness check to pass for dependabot PRs ([#23](https://github.com/coloneljade/merge-bot/pull/23))
 - Bump actions to Node.js 24 compatible versions ([#24](https://github.com/coloneljade/merge-bot/pull/24))
+- Replace deprecated app-id input with client-id ([#27](https://github.com/coloneljade/merge-bot/pull/27))

--- a/README.md
+++ b/README.md
@@ -30,11 +30,11 @@ concurrency:
 jobs:
   merge:
     if: github.event.issue.pull_request && startsWith(github.event.comment.body, '/merge')
-    uses: coloneljade/merge-bot/.github/workflows/merge.yml@v1
+    uses: coloneljade/merge-bot/.github/workflows/merge.yml@v2
     with:
       bump-map: '{"feature":"minor","feat":"minor","fix":"patch"}'
     secrets:
-      app-id: ${{ secrets.MERGE_APP_ID }}
+      client-id: ${{ secrets.MERGE_CLIENT_ID }}
       private-key: ${{ secrets.MERGE_APP_PRIVATE_KEY }}
 ```
 
@@ -64,7 +64,7 @@ Flags can be combined: `/merge --patch --no-squash`
 
 | Secret | Description |
 |--------|-------------|
-| `app-id` | GitHub App ID for `auldrant-merge-bot` |
+| `client-id` | GitHub App Client ID for `auldrant-merge-bot` |
 | `private-key` | Private key (.pem) for the GitHub App |
 
 Set these as repository secrets in each consuming repo under Settings > Secrets and variables > Actions.
@@ -151,12 +151,12 @@ permissions:
   checks: read
 jobs:
   readiness:
-    uses: coloneljade/merge-bot/.github/workflows/readiness.yml@v1
+    uses: coloneljade/merge-bot/.github/workflows/readiness.yml@v2
     with:
       pr-number: ${{ github.event.pull_request.number }}
       pr-sha: ${{ github.event.pull_request.head.sha }}
     secrets:
-      app-id: ${{ secrets.MERGE_APP_ID }}
+      client-id: ${{ secrets.MERGE_CLIENT_ID }}
       private-key: ${{ secrets.MERGE_APP_PRIVATE_KEY }}
 ```
 
@@ -194,7 +194,7 @@ Go to **github.com > Settings > Developer settings > GitHub Apps > New GitHub Ap
 No user/org permissions needed. Subscribe to no events.
 
 After creation:
-1. Note the **App ID** from the app settings page
+1. Note the **Client ID** from the app settings page (under **About** — distinct from the **App ID**)
 2. Under **Private keys**, generate a key and download the `.pem` file
 
 ### 2. Install the App
@@ -207,7 +207,7 @@ In each consuming repo: **Settings > Secrets and variables > Actions > New repos
 
 | Secret name | Value |
 |-------------|-------|
-| `MERGE_APP_ID` | The App ID number |
+| `MERGE_CLIENT_ID` | The GitHub App Client ID (e.g. `Iv23li…`) |
 | `MERGE_APP_PRIVATE_KEY` | Full contents of the `.pem` file |
 
 ### 4. Create Branch Ruleset


### PR DESCRIPTION
### Fixed

- Replace deprecated `app-id` input on `actions/create-github-app-token@v3` with `client-id` in both reusable workflows (Fixes #26)
- Pin auto-tag workflow to `v2` so `v1` stays frozen at the last `app-id`-compatible commit and consumers can migrate on their own schedule

### Documentation

- Update README Quick Start, Readiness Check, Secrets Reference, and GitHub Setup to reference Client ID and `MERGE_CLIENT_ID`
- Bump example `@v1` references to `@v2`

## Breaking Change

Callers must update both YAML and the secret value:

1. Bump `@v1` → `@v2` and rename the secrets block:
   ```yaml
   secrets:
     client-id: ${{ secrets.MERGE_CLIENT_ID }}
     private-key: ${{ secrets.MERGE_APP_PRIVATE_KEY }}
   ```
2. Set the `MERGE_CLIENT_ID` repo secret to the GitHub App's **Client ID** (not the App ID — both are listed on the App settings page).

`v1` tag is intentionally not moved; consumers pinned to `@v1` keep working until they migrate.

## Test Plan

- [ ] Readiness check passes on this PR using the new `client-id` workflow
- [ ] After merge, `update-tag.yml` creates `v2` at the merge commit
- [ ] After merge, `v1` tag remains at `ba19471`